### PR TITLE
Email Pattern built wrong

### DIFF
--- a/js/scrupulous.js
+++ b/js/scrupulous.js
@@ -17,7 +17,7 @@
 
     var $forms        = this,
         $inputs       = $forms.find('select, input, textarea'),
-        emailPattern  = "[^@]+@[^@]+\.[a-zA-Z]{2,6}",
+        emailPattern  = "[^@]+@[^@]+\\.[a-zA-Z]{2,6}",
         browser       = {},
         $el,$form,$formGroup,elId,validity,errorMessage;
 


### PR DESCRIPTION
escaping dot in regex, _when storing in a string_, requires double escaping for the backslash. With given pattern it would allow "scrupulous@github" just as it would "scrupulous@github.com".